### PR TITLE
Conditionally unprefix nodes

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -71,6 +71,10 @@ var config = {
   }
 };
 
+function unprefix(root, node, prefix) {
+  return root[prefix + ':' + node] || root[node];
+}
+
 /**
  * Initialize a new instance of a Firefox Profile
  *
@@ -344,9 +348,11 @@ FirefoxProfile.prototype._addonDetails = function(addonPath, cb) {
   var doc = fs.readFileSync(path.join(addonPath, 'install.rdf'));
   parseString(doc, function (err, doc) {
     var em = getNamespaceId(doc, "http://www.mozilla.org/2004/em-rdf#"),
-    rdf = getNamespaceId(doc, "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+      rdf = getNamespaceId(doc, "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
     // first description
-    var description = doc[rdf + ':RDF'][rdf + ':Description'];
+    var rdfNode = unprefix(doc, 'RDF', rdf);
+    var description = unprefix(rdfNode, 'Description', rdf);
+
     if (description && description[0]) {
       description = description[0];
     }
@@ -356,10 +362,17 @@ FirefoxProfile.prototype._addonDetails = function(addonPath, cb) {
       }
 
     });
+    Object.keys(description).forEach(function(attr) {
+      if (details[attr.replace(em + ':', '')] !== undefined) {
+        details[attr.replace(em + ':', '')] = description[attr][0];
+      }
+
+    });
+
     cb && cb(details);
 
   });
-  
+
 };
 
 FirefoxProfile.prototype._createTempFolder = function(suffix) {


### PR DESCRIPTION
Also adds support for use of child nodes in `<Description>` rather than attributes.
See #2
