### PR TITLE
Potential EMFILE when installing multiple large extensions

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -10,7 +10,8 @@ var os = require('os'),
     wrench = require('wrench'),
     AdmZip = require('adm-zip'),
     archiver = require('archiver'),
-    uuid = require('node-uuid');
+    uuid = require('node-uuid'),
+    Readable = require('lazystream').Readable;
 
 var config = {
   // from python... Not used
@@ -229,8 +230,11 @@ FirefoxProfile.prototype.encoded = function(cb) {
   archive.pipe(zipStream);
   files.forEach(function(filePath) {
     if (fs.statSync(path.join(self.profileDir, filePath)).isFile()) {
+      var srcStream = new Readable(function() {
+        return fs.createReadStream(path.join(self.profileDir, filePath));
+      });
 
-      archive.append(path.join(self.profileDir, filePath), { name: filePath });
+      archive.append(srcStream, { name: filePath });
     }
 
   });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "adm-zip": "~0.4.3",
     "xml2js": "~0.2.8",
     "node-uuid": "~1.4.1",
-    "archiver": "~0.4.10"
+    "archiver": "~0.4.10",
+    "lazystream": "~0.1.0"
   }
 }


### PR DESCRIPTION
Now utilizes 'lazystream' module to prevent EMFILE exceptions.
