### PR TITLE
Fix how IDs work with native jetpack addons

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -11,7 +11,8 @@ var os = require('os'),
     uuid = require('node-uuid'),
     Readable = require('lazystream').Readable,
     async = require('async'),
-    uuid = require('node-uuid');
+    uuid = require('node-uuid'),
+    getID = require('jetpack-id');
 
 var config = {
   // from python... Not used
@@ -425,7 +426,7 @@ FirefoxProfile.prototype._installExtension = function(addon, cb) {
 
   // find out the addon id
   this._addonDetails(addon, function(addonDetails) {
-    var addonId = addonDetails.id;
+    var addonId = getID(addonDetails);
     var unpack = addonDetails.unpack === undefined ? true : addonDetails.unpack;
 
     if (!addonId) {
@@ -458,7 +459,8 @@ FirefoxProfile.prototype._addonDetails = function(addonPath, cb) {
     'id': null,
     'name': null,
     'unpack': true,
-    'version': null
+    'version': null,
+    'isNative': false
   }, self = this;
 
   function getNamespaceId(doc, url) {
@@ -485,6 +487,7 @@ FirefoxProfile.prototype._addonDetails = function(addonPath, cb) {
     var manifest = require(path.join(addonPath, 'package.json'));
     // Jetpack addons are packed by default
     details.unpack = false;
+    details.isNative = true;
     Object.keys(details).forEach(function (prop) {
       if (manifest[prop] !== undefined) {
         details[prop] = manifest[prop];

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "wd": "~0.2.5"
   },
   "dependencies": {
+    "jetpack-id": "0.0.4",
     "adm-zip": "~0.4.3",
     "archiver": "~0.10",
     "async": "~0.9.0",

--- a/test/firefox_profile.js
+++ b/test/firefox_profile.js
@@ -172,6 +172,7 @@ describe('firefox_profile', function() {
           id: 'no-namespace@test.test',
           name: 'test-extension without namespace',
           unpack: true,
+          isNative: false,
           version: '2.1.0'
         });
         done();
@@ -184,6 +185,7 @@ describe('firefox_profile', function() {
           id: 'with-namespace@test.test',
           name: 'test-extension with namespace',
           unpack: false,
+          isNative: false,
           version: '2.2.99'
         });
         done();
@@ -196,6 +198,7 @@ describe('firefox_profile', function() {
           id: 'jetpack-addon@test.test',
           name: 'Jetpack-addon-test',
           unpack: false,
+          isNative: true,
           version: '0.0.1'
         });
         done();


### PR DESCRIPTION
We've just launched [jpm](https://github.com/mozilla/jpm) into beta, with new rules for IDs, maintained in the [jetpack-id](https://github.com/jsantell/jetpack-id) module, and after testing with my fork, I think we're good to go to merge this in and start using your module in npm :smile: 

All tests passing again, but can't test the coverage/saucelabs stuff, let me know if this works for you to get merged in!
