### PR TITLE
Exit process on SIGINT

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -139,6 +139,7 @@ function FirefoxProfile(options) {
   ['exit', 'SIGINT'].forEach(function(event) {
     process.addListener(event, self.onExit);
   });
+  process.addListener('SIGINT', process.exit);
 }
 
 function deleteParallel(files, cb) {


### PR DESCRIPTION
Listening for SIGINT seems to make node not exit the process after processing the listener. This will aid in fixing mozilla/jpm#120
