### PR TITLE
addExtension() callback not called fix

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -590,6 +590,8 @@ FirefoxProfile.prototype._installExtension = function(addon, cb) {
           wrench.rmdirRecursive(tmpDir, function() {
             next();
           });
+        } else {
+          next();
         }
       }
     ], function() {


### PR DESCRIPTION
When `FirefoxProfile.prototype.addExtension` is called with unpacked
addon directory as parameter (not an .xpi file), the callback is not
called.

This patch fixes that by ensuring that all passes of item of
`async.series` will call `next`.