### PR TITLE
use remove method instead of unlink

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -151,7 +151,7 @@ function FirefoxProfile(options) {
 
 function deleteParallel(files, cb) {
   async.parallel(files.map(function(file) {
-    return function(next) { fs.unlink(file, next); };
+    return function(next) { fs.remove(file, next); };
   }), function () {
     cb && cb();
   });


### PR DESCRIPTION
Method `encode` currently leaves tmp directories in `/tmp/` after exit.
It caused by trying to remove directory using `unlink`.