### PR TITLE
fix: Read existing user js preferences

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -133,6 +133,9 @@ function FirefoxProfile(options) {
   }
   this.extensionsDir = path.join(this.profileDir, 'extensions');
   this.userPrefs = path.join(this.profileDir, 'user.js');
+  if (fs.existsSync(this.userPrefs)) {
+    this._readExistingUserjs();
+  }
 
   // delete on process.exit()...
   var self = this;


### PR DESCRIPTION
There was no call to initialize already existent js preferences. This
fixes that by using the already provided method (which is otherwise not
called from anywhere).