### PR TITLE
update typings for typescript

### DIFF
--- a/lib/firefox_profile.d.ts
+++ b/lib/firefox_profile.d.ts
@@ -70,8 +70,8 @@ declare class FirefoxProfile {
 	setAssumeUntrustedCertIssuer(assumeUntrusted: boolean): void;
 	nativeEventsEnabled(): boolean;
 	setNativeEventsEnabled(enabled: boolean): void;
-	encoded(cb: (encodedProfile: string) => void): void;
-	encode(cb: (encodedProfile: string) => void): void;
+	encoded(cb: (err: any, encodedProfile: string) => void): void;
+	encode(cb: (err: any, encodedProfile: string) => void): void;
 	setProxy(proxySettings: ProxySettings): void;
 }
 


### PR DESCRIPTION
I updated the typings to reflect the change to the `encoded` method.