### PR TITLE
fix reading strings from an existing user.js

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -527,7 +527,7 @@ FirefoxProfile.prototype._writeUserPrefs = function(userPrefs) {
 
 FirefoxProfile.prototype._readExistingUserjs = function() {
   var self = this,
-      regExp = /user_pref\(['"](.*)["'],\s*['"]?(.*)["']?\)/,
+      regExp = /user_pref\(['"](.*)["'],\s*(.*)\)/,
       contentLines = fs.readFileSync(this.userPrefs, "utf8").split('\n');
   contentLines.forEach(function(line) {
     var found = line.match(regExp);


### PR DESCRIPTION
The regular expression tries to remove the quotation marks around a string value (actually it only removes the quotation mark at the beginning but not at the end), but it shouldn't because string values are stored in `defaultPreferences` _with_ quotation marks (as can be seen in `FirefoxProfile#setPreference`).
See also firefox-devtools/vscode-firefox-debug#175.