### PR TITLE
Drop `async`

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -12,7 +12,6 @@ var os = require('os'),
   AdmZip = require('adm-zip'),
   archiver = require('archiver'),
   uuid = require('uuid'),
-  async = require('async'),
   getID = require('jetpack-id'),
   _ = require('lodash'),
   Finder = require('./profile_finder');

--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -350,13 +350,11 @@ FirefoxProfile.prototype.addExtension = function (extension, cb) {
  */
 
 FirefoxProfile.prototype.addExtensions = function (extensions, cb) {
-  var self = this,
-    functions = extensions.map(function (extension) {
-      return function (callback) {
-        self.addExtension(path.normalize(extension), callback);
-      };
-    });
-  async.parallel(functions, cb);
+  var addExtension = util.promisify(this.addExtension.bind(this));
+  var promises = extensions.map(extension =>
+    addExtension(path.normalize(extension))
+  );
+  util.callbackify(() => Promise.all(promises))(cb);
 };
 
 /**

--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -591,57 +591,27 @@ FirefoxProfile.prototype._installExtension = function (addon, cb) {
       cb(new Error('FirefoxProfile: the addon id could not be found!'));
     }
     var addonPath = path.join(self.extensionsDir, path.sep, addonId);
-    async.series(
-      [
-        // creates extensionsDir
-        function (next) {
-          fs.exists(self.extensionsDir, function (exists) {
-            if (!exists) {
-              fs.mkdir(self.extensionsDir, function () {
-                next();
-              });
-              return;
-            }
-            // already exists
-            next();
-          });
-        },
-        function (next) {
-          if (!unpack && xpiFile) {
-            fs.copy(xpiFile, addonPath + '.xpi', function () {
-              next();
-            });
-          } else {
-            // copy it!
-            fs.mkdir(addonPath, function () {
-              fs.copy(
-                addon,
-                addonPath,
-                {
-                  clobber: true,
-                },
-                function () {
-                  next();
-                }
-              );
-            });
+    util.callbackify(async function run() {
+      await fs.mkdirp(self.extensionsDir);
+      if (!unpack && xpiFile) {
+        await fs.copy(xpiFile, addonPath + '.xpi');
+      } else {
+        await fs.mkdir(addonPath);
+        await fs.copy(
+          addon,
+          addonPath,
+          {
+            clobber: true,
           }
-        },
-        function (next) {
-          if (tmpDir) {
-            fs.remove(tmpDir, function () {
-              next();
-            });
-          } else {
-            next();
-          }
-        },
-      ],
-      function () {
-        // done!
-        cb && cb(null, addonDetails);
+        );
       }
-    );
+
+      if (tmpDir) {
+        await fs.remove(tmpDir);
+      }
+
+      return addonDetails;
+    })(cb)
   });
 };
 

--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -5,6 +5,7 @@
 
 var os = require('os'),
   path = require('path'),
+  util = require('util'),
   fs = require('fs-extra'),
   // third-party
   parseString = require('xml2js').parseString,
@@ -149,19 +150,6 @@ function FirefoxProfile(options) {
   };
   process.addListener('exit', self.onExit);
   process.addListener('SIGINT', self.onSigInt);
-}
-
-function deleteParallel(files, cb) {
-  async.parallel(
-    files.map(function (file) {
-      return function (next) {
-        fs.remove(file, next);
-      };
-    }),
-    function () {
-      cb && cb();
-    }
-  );
 }
 
 FirefoxProfile.prototype._copy = function (profileDirectory, cb) {
@@ -466,7 +454,8 @@ FirefoxProfile.prototype.encoded = function (cb) {
     zipStream.on('close', function () {
       fs.readFile(path.join(tmpFolder, 'profile.zip'), function (err, content) {
         cb(null, content.toString('base64'));
-        deleteParallel([path.join(tmpFolder, 'profile.zip'), tmpFolder]);
+        fs.remove(path.join(tmpFolder, 'profile.zip'));
+        fs.remove(tmpFolder);
       });
     });
     archive.pipe(zipStream);

--- a/package-lock.json
+++ b/package-lock.json
@@ -185,6 +185,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "dev": true,
       "requires": {
         "lodash": "^4.14.0"
       },
@@ -192,7 +193,8 @@
         "lodash": {
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "dependencies": {
     "adm-zip": "~0.4.x",
     "archiver": "~5.0.2",
-    "async": "~2.5.0",
     "fs-extra": "~4.0.2",
     "ini": "~1.3.3",
     "jetpack-id": "1.0.0",


### PR DESCRIPTION
Callback hell should be behind us. I replaced `async` module with promises and async functions (Node 7.6+). Promisify/callbackify (Node 8+) was used to avoid overhauling/promisifying the whole API.

You can see how `_addonDetails` makes _a lot_ more sense now since it's like 70% shorter.
