### PR TITLE
Fix `rm` on non-empty dir

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -285,7 +285,7 @@ FirefoxProfile.prototype.deleteDir = function (cb) {
 FirefoxProfile.prototype._cleanOnExit = function () {
   if (fs.existsSync(this.profileDir)) {
     try {
-      fs.removeSync(this.profileDir);
+      fs.rmSync(this.profileDir, {recursive: true, force: true});
     } catch (e) {
       console.warn(
         '[firefox-profile] cannot delete profileDir on exit',


### PR DESCRIPTION
This fixes a issue I've been running into, whereby the `tmp/firefox-xxxx` wasn't empty(polluted with some tracing data?) and firefox-profile will error about not able to remove the directory due to it wasn't empty.