### PR TITLE
Fix issues while copying userPref profile

### DIFF
--- a/lib/firefox_profile.js
+++ b/lib/firefox_profile.js
@@ -211,6 +211,7 @@ FirefoxProfile.copy = function (options, cb) {
     return;
   }
   var profile = new FirefoxProfile({
+    profileDirectory: opts.profileDirectory,
     destinationDirectory: opts.destinationDirectory,
   });
   profile._copy(opts.profileDirectory, function () {


### PR DESCRIPTION
- When the `profileDirectory` is specified, the preferences provided are not copied because the `profileDirectory` parameter is not passed.
- This issue results in a [bug](https://github.com/webdriverio/webdriverio/issues/11879) where profiles are not copied during runtime. 
- The unit test operates effectively with the parameter being correctly passed. Therefore, it remains unchanged.